### PR TITLE
Add minimal PHP inventory system skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/*.json
+data/*.log

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a minimal PHP inventory system skeleton providing:
 - Purchase (GRN) workflow updating stock and average cost.
 - User authentication with role-based JWT tokens and simple audit logging.
 - Language files for English and French located in `app/lang`.
+- Runtime language can be toggled with the `Lang` helper using `?lang=en` or `?lang=fr`.
 - Basic REST API endpoints under `/api`.
 
-This code is intentionally lightweight and uses JSON files in the `data/` directory for persistence.
+This code is intentionally lightweight and uses JSON files in the `data/` directory for persistence. Ensure the `data/` directory is writable by the web server.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Inventory-system
+# Inventory System
+
+This is a minimal PHP inventory system skeleton providing:
+
+- Product CRUD with barcode generation and CSV import/export.
+- POS checkout that validates stock and records audit logs.
+- Purchase (GRN) workflow updating stock and average cost.
+- User authentication with role-based JWT tokens and simple audit logging.
+- Language files for English and French located in `app/lang`.
+- Basic REST API endpoints under `/api`.
+
+This code is intentionally lightweight and uses JSON files in the `data/` directory for persistence.

--- a/api.php
+++ b/api.php
@@ -1,0 +1,37 @@
+<?php
+require_once __DIR__ . '/app/Product.php';
+require_once __DIR__ . '/app/Pos.php';
+require_once __DIR__ . '/app/GRN.php';
+require_once __DIR__ . '/app/Auth.php';
+
+header('Content-Type: application/json');
+$method = $_SERVER['REQUEST_METHOD'];
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+function authUser() {
+    $headers = getallheaders();
+    if (!isset($headers['Authorization'])) return null;
+    $token = trim(str_replace('Bearer', '', $headers['Authorization']));
+    return Auth::jwtDecode($token);
+}
+
+switch (true) {
+    case $path === '/api/login' && $method === 'POST':
+        $data = json_decode(file_get_contents('php://input'), true);
+        $token = Auth::login($data['name'], $data['password']);
+        echo json_encode(['token'=>$token]);
+        break;
+    case $path === '/api/products' && $method === 'GET':
+        echo json_encode(Product::all());
+        break;
+    case $path === '/api/products' && $method === 'POST':
+        $user = authUser();
+        if (!$user || $user['role'] !== 'admin') {http_response_code(403); break;}
+        $data = json_decode(file_get_contents('php://input'), true);
+        $product = Product::create($data['name'], $data['price'], $data['stock']);
+        echo json_encode($product);
+        break;
+    default:
+        http_response_code(404);
+        echo json_encode(['error'=>'Not found']);
+}

--- a/api.php
+++ b/api.php
@@ -3,10 +3,12 @@ require_once __DIR__ . '/app/Product.php';
 require_once __DIR__ . '/app/Pos.php';
 require_once __DIR__ . '/app/GRN.php';
 require_once __DIR__ . '/app/Auth.php';
+require_once __DIR__ . '/app/Lang.php';
 
 header('Content-Type: application/json');
 $method = $_SERVER['REQUEST_METHOD'];
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+Lang::setLocale($_GET['lang'] ?? 'en');
 
 function authUser() {
     $headers = getallheaders();
@@ -19,6 +21,7 @@ switch (true) {
     case $path === '/api/login' && $method === 'POST':
         $data = json_decode(file_get_contents('php://input'), true);
         $token = Auth::login($data['name'], $data['password']);
+        if (!$token) {http_response_code(401); echo json_encode(['error'=>Lang::get('login_failed')]); break;}
         echo json_encode(['token'=>$token]);
         break;
     case $path === '/api/products' && $method === 'GET':
@@ -26,12 +29,12 @@ switch (true) {
         break;
     case $path === '/api/products' && $method === 'POST':
         $user = authUser();
-        if (!$user || $user['role'] !== 'admin') {http_response_code(403); break;}
+        if (!$user || $user['role'] !== 'admin') {http_response_code(403); echo json_encode(['error'=>Lang::get('unauthorized')]); break;}
         $data = json_decode(file_get_contents('php://input'), true);
         $product = Product::create($data['name'], $data['price'], $data['stock']);
         echo json_encode($product);
         break;
     default:
         http_response_code(404);
-        echo json_encode(['error'=>'Not found']);
+        echo json_encode(['error'=>Lang::get('not_found')]);
 }

--- a/app/AuditLog.php
+++ b/app/AuditLog.php
@@ -1,0 +1,11 @@
+<?php
+class AuditLog
+{
+    private static $file = __DIR__ . '/../data/audit.log';
+
+    public static function log($user, $action)
+    {
+        $entry = date('c') . "|{$user}|{$action}\n";
+        file_put_contents(self::$file, $entry, FILE_APPEND);
+    }
+}

--- a/app/Auth.php
+++ b/app/Auth.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/User.php';
+
+class Auth
+{
+    private static $secret = 'secretkey';
+
+    public static function login($name, $password)
+    {
+        $user = User::findByName($name);
+        if ($user && password_verify($password, $user->password)) {
+            return self::jwtEncode(['id'=>$user->id,'role'=>$user->role]);
+        }
+        return null;
+    }
+
+    public static function jwtEncode($payload)
+    {
+        $header = base64_encode(json_encode(['alg'=>'HS256','typ'=>'JWT']));
+        $body = base64_encode(json_encode($payload));
+        $sig = hash_hmac('sha256', "$header.$body", self::$secret, true);
+        return "$header.$body." . base64_encode($sig);
+    }
+
+    public static function jwtDecode($token)
+    {
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) return null;
+        list($header, $body, $signature) = $parts;
+        $expected = base64_encode(hash_hmac('sha256', "$header.$body", self::$secret, true));
+        if (!hash_equals($expected, $signature)) return null;
+        return json_decode(base64_decode($body), true);
+    }
+}

--- a/app/GRN.php
+++ b/app/GRN.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/Product.php';
+require_once __DIR__ . '/AuditLog.php';
+
+class GRN
+{
+    public static function receive($user, $supplier, $items)
+    {
+        foreach ($items as $item) {
+            $product = Product::find($item['id']);
+            if (!$product) {
+                $product = Product::create($item['name'], $item['cost'], $item['qty']);
+            } else {
+                $totalCost = $product->stock * $product->price + $item['qty'] * $item['cost'];
+                $product->stock += $item['qty'];
+                $product->price = $totalCost / $product->stock;
+                $product->update([]);
+            }
+        }
+        AuditLog::log($user, 'grn');
+    }
+}

--- a/app/Lang.php
+++ b/app/Lang.php
@@ -1,0 +1,20 @@
+<?php
+class Lang
+{
+    private static $messages = [];
+    private static $locale = 'en';
+
+    public static function setLocale($locale)
+    {
+        $path = __DIR__ . "/lang/{$locale}.php";
+        if (file_exists($path)) {
+            self::$messages = require $path;
+            self::$locale = $locale;
+        }
+    }
+
+    public static function get($key)
+    {
+        return self::$messages[$key] ?? $key;
+    }
+}

--- a/app/Pos.php
+++ b/app/Pos.php
@@ -6,6 +6,9 @@ class Pos
 {
     public static function checkout($user, $client, $items)
     {
+        if (!$client) {
+            throw new Exception('Client required');
+        }
         $total = 0;
         $lines = [];
         foreach ($items as $item) {
@@ -39,7 +42,7 @@ class Pos
         foreach ($lines as $l) {
             $html .= "<tr><td>{$l['name']}</td><td>{$l['qty']}</td><td>{$l['price']}</td><td>{$l['total']}</td></tr>";
         }
-        $html .= "</table><p>Total: {$total}</p>";
+        $html .= "</table><p>Total: {$total}</p><p>Thank you for your purchase</p>";
         return $html;
     }
 

--- a/app/Pos.php
+++ b/app/Pos.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__ . '/Product.php';
+require_once __DIR__ . '/AuditLog.php';
+
+class Pos
+{
+    public static function checkout($user, $client, $items)
+    {
+        $total = 0;
+        $lines = [];
+        foreach ($items as $item) {
+            $product = Product::find($item['id']);
+            if (!$product || $product->stock < $item['qty']) {
+                throw new Exception('Insufficient stock for product ' . $item['id']);
+            }
+            $product->stock -= $item['qty'];
+            $product->update([]);
+            $lineTotal = $item['qty'] * $product->price;
+            $total += $lineTotal;
+            $lines[] = [
+                'name' => $product->name,
+                'qty' => $item['qty'],
+                'price' => $product->price,
+                'total' => $lineTotal,
+            ];
+            if ($product->stock < 5) {
+                self::sendWhatsAppAlert("Low stock for {$product->name}");
+            }
+        }
+        $receiptHtml = self::renderReceipt($client, $lines, $total);
+        $receiptPdf = self::generatePdf($receiptHtml);
+        AuditLog::log($user, 'checkout');
+        return ['html' => $receiptHtml, 'pdf' => $receiptPdf];
+    }
+
+    private static function renderReceipt($client, $lines, $total)
+    {
+        $html = "<h1>Receipt for {$client}</h1><table><tr><th>Product</th><th>Qty</th><th>Price</th><th>Total</th></tr>";
+        foreach ($lines as $l) {
+            $html .= "<tr><td>{$l['name']}</td><td>{$l['qty']}</td><td>{$l['price']}</td><td>{$l['total']}</td></tr>";
+        }
+        $html .= "</table><p>Total: {$total}</p>";
+        return $html;
+    }
+
+    private static function generatePdf($html)
+    {
+        // TODO: integrate real PDF library
+        $tmp = tempnam(sys_get_temp_dir(), 'pdf');
+        file_put_contents($tmp, $html);
+        return $tmp;
+    }
+
+    private static function sendWhatsAppAlert($message)
+    {
+        // TODO: integrate with WhatsApp API
+        file_put_contents(__DIR__ . '/../data/whatsapp.log', $message . "\n", FILE_APPEND);
+    }
+}

--- a/app/Product.php
+++ b/app/Product.php
@@ -63,7 +63,7 @@ class Product
     public static function create($name, $price, $stock)
     {
         $products = self::all();
-        $id = count($products) + 1;
+        $id = $products ? max(array_map(function($p){return $p->id;}, $products)) + 1 : 1;
         $product = new self($id, $name, $price, $stock);
         $products[] = $product;
         self::saveAll($products);

--- a/app/Product.php
+++ b/app/Product.php
@@ -1,0 +1,128 @@
+<?php
+
+class Product
+{
+    public $id;
+    public $name;
+    public $price;
+    public $stock;
+    public $barcode;
+
+    private static $dataFile = __DIR__ . '/../data/products.json';
+
+    public function __construct($id, $name, $price, $stock, $barcode = null)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->price = $price;
+        $this->stock = $stock;
+        $this->barcode = $barcode ?: self::generateBarcode($id);
+    }
+
+    public static function generateBarcode($seed)
+    {
+        return str_pad($seed, 12, '0', STR_PAD_LEFT);
+    }
+
+    public static function all()
+    {
+        if (!file_exists(self::$dataFile)) {
+            return [];
+        }
+        $json = file_get_contents(self::$dataFile);
+        $data = json_decode($json, true) ?: [];
+        return array_map(function ($item) {
+            return new self($item['id'], $item['name'], $item['price'], $item['stock'], $item['barcode']);
+        }, $data);
+    }
+
+    public static function find($id)
+    {
+        foreach (self::all() as $product) {
+            if ($product->id == $id) {
+                return $product;
+            }
+        }
+        return null;
+    }
+
+    public static function saveAll($products)
+    {
+        $data = array_map(function ($p) {
+            return [
+                'id' => $p->id,
+                'name' => $p->name,
+                'price' => $p->price,
+                'stock' => $p->stock,
+                'barcode' => $p->barcode,
+            ];
+        }, $products);
+        file_put_contents(self::$dataFile, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public static function create($name, $price, $stock)
+    {
+        $products = self::all();
+        $id = count($products) + 1;
+        $product = new self($id, $name, $price, $stock);
+        $products[] = $product;
+        self::saveAll($products);
+        return $product;
+    }
+
+    public function update($fields)
+    {
+        foreach ($fields as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+            }
+        }
+        $products = self::all();
+        foreach ($products as $index => $p) {
+            if ($p->id == $this->id) {
+                $products[$index] = $this;
+                break;
+            }
+        }
+        self::saveAll($products);
+    }
+
+    public function delete()
+    {
+        $products = array_filter(self::all(), function ($p) {
+            return $p->id != $this->id;
+        });
+        self::saveAll(array_values($products));
+    }
+
+    public static function exportCSV()
+    {
+        $products = self::all();
+        $fp = fopen('php://temp', 'r+');
+        fputcsv($fp, ['id','name','price','stock','barcode']);
+        foreach ($products as $p) {
+            fputcsv($fp, [$p->id, $p->name, $p->price, $p->stock, $p->barcode]);
+        }
+        rewind($fp);
+        return stream_get_contents($fp);
+    }
+
+    public static function importCSV($csv)
+    {
+        $fp = fopen('php://temp', 'r+');
+        fwrite($fp, $csv);
+        rewind($fp);
+        $rows = [];
+        while (($row = fgetcsv($fp)) !== false) {
+            $rows[] = $row;
+        }
+        fclose($fp);
+        $products = [];
+        foreach (array_slice($rows, 1) as $row) {
+            [$id, $name, $price, $stock, $barcode] = $row;
+            $products[] = new self($id, $name, $price, $stock, $barcode);
+        }
+        self::saveAll($products);
+        return $products;
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -1,0 +1,52 @@
+<?php
+class User
+{
+    public $id;
+    public $name;
+    public $password;
+    public $role;
+
+    private static $dataFile = __DIR__ . '/../data/users.json';
+
+    public function __construct($id, $name, $password, $role)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->password = $password;
+        $this->role = $role;
+    }
+
+    public static function all()
+    {
+        if (!file_exists(self::$dataFile)) {return [];}    
+        $json = file_get_contents(self::$dataFile);
+        $data = json_decode($json, true) ?: [];
+        return array_map(function($u){return new self($u['id'],$u['name'],$u['password'],$u['role']);}, $data);
+    }
+
+    public static function findByName($name)
+    {
+        foreach (self::all() as $u) {
+            if ($u->name === $name) return $u;
+        }
+        return null;
+    }
+
+    public static function create($name, $password, $role)
+    {
+        $users = self::all();
+        $id = count($users) + 1;
+        $user = new self($id, $name, password_hash($password, PASSWORD_DEFAULT), $role);
+        $users[] = $user;
+        self::saveAll($users);
+        return $user;
+    }
+
+    public static function saveAll($users)
+    {
+        $data = array_map(function($u){
+            return ['id'=>$u->id,'name'=>$u->name,'password'=>$u->password,'role'=>$u->role];
+        }, $users);
+        file_put_contents(self::$dataFile, json_encode($data, JSON_PRETTY_PRINT));
+    }
+}

--- a/app/lang/en.php
+++ b/app/lang/en.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'welcome' => 'Welcome',
+    'product' => 'Product',
+    'checkout' => 'Checkout',
+];

--- a/app/lang/en.php
+++ b/app/lang/en.php
@@ -3,4 +3,7 @@ return [
     'welcome' => 'Welcome',
     'product' => 'Product',
     'checkout' => 'Checkout',
+    'unauthorized' => 'Unauthorized',
+    'not_found' => 'Not Found',
+    'login_failed' => 'Invalid credentials',
 ];

--- a/app/lang/fr.php
+++ b/app/lang/fr.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'welcome' => 'Bienvenue',
+    'product' => 'Produit',
+    'checkout' => 'Caisse',
+];

--- a/app/lang/fr.php
+++ b/app/lang/fr.php
@@ -3,4 +3,7 @@ return [
     'welcome' => 'Bienvenue',
     'product' => 'Produit',
     'checkout' => 'Caisse',
+    'unauthorized' => 'Non autorisé',
+    'not_found' => 'Introuvable',
+    'login_failed' => 'Identifiants invalides',
 ];


### PR DESCRIPTION
## Summary
- add Product model with barcode generation, JSON storage, and CSV import/export
- implement POS checkout with receipt stubs and WhatsApp alerts
- add GRN receiver updating stock and average cost
- create basic user model and JWT auth plus language files and REST API

## Testing
- `php -l app/Product.php`
- `php -l app/Pos.php`
- `php -l app/AuditLog.php`
- `php -l app/GRN.php`
- `php -l app/User.php`
- `php -l app/Auth.php`
- `php -l api.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb7fa7a348332a3d7219eed763d62