### PR TITLE
Add database migration and seeder scripts

### DIFF
--- a/scripts/db_migrations.sql
+++ b/scripts/db_migrations.sql
@@ -1,0 +1,78 @@
+-- Database schema for Inventory System
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin','worker') NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE suppliers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    contact_info VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    supplier_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    stock INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_category (category_id),
+    INDEX idx_supplier (supplier_id),
+    CONSTRAINT fk_products_category FOREIGN KEY (category_id) REFERENCES categories(id),
+    CONSTRAINT fk_products_supplier FOREIGN KEY (supplier_id) REFERENCES suppliers(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE customers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    contact_info VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE workers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    contact_info VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_workers_user (user_id),
+    CONSTRAINT fk_workers_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE sales (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    product_id INT NOT NULL,
+    customer_id INT NOT NULL,
+    worker_id INT NOT NULL,
+    quantity INT NOT NULL,
+    total DECIMAL(10,2) NOT NULL,
+    sale_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_product (product_id),
+    INDEX idx_customer (customer_id),
+    INDEX idx_worker (worker_id),
+    CONSTRAINT fk_sales_product FOREIGN KEY (product_id) REFERENCES products(id),
+    CONSTRAINT fk_sales_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
+    CONSTRAINT fk_sales_worker FOREIGN KEY (worker_id) REFERENCES workers(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE audit_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_log_user (user_id),
+    CONSTRAINT fk_logs_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB;

--- a/scripts/seeders.sql
+++ b/scripts/seeders.sql
@@ -1,0 +1,29 @@
+-- Seed data for Inventory System
+-- Passwords generated using PHP password_hash()
+
+INSERT INTO users (username, password, role) VALUES
+('admin', '$2y$12$oYBs4LNTDdp95CqhUQAENOdm8VNysCwwYZ8M74HEe66pjoBPaHYe2', 'admin'),
+('jdoe', '$2y$12$RSQAOxq5yd99Me04QCZ.be.BJL16mpprLTpQ6SPiJfdn/oMFbFeZC', 'worker');
+
+INSERT INTO categories (name) VALUES
+('Electronics'),
+('Furniture');
+
+INSERT INTO suppliers (name, contact_info) VALUES
+('Acme Corp', 'acme@example.com');
+
+INSERT INTO products (category_id, supplier_id, name, price, stock) VALUES
+(1, 1, 'Laptop', 999.99, 10),
+(2, 1, 'Office Chair', 199.99, 20);
+
+INSERT INTO workers (user_id, name, contact_info) VALUES
+(2, 'John Doe', 'john@example.com');
+
+INSERT INTO customers (name, contact_info) VALUES
+('Jane Customer', 'jane@example.com');
+
+INSERT INTO sales (product_id, customer_id, worker_id, quantity, total) VALUES
+(1, 1, 1, 1, 999.99);
+
+INSERT INTO audit_logs (user_id, action) VALUES
+(1, 'Initial data seeding');


### PR DESCRIPTION
## Summary
- add SQL schema defining core inventory tables with foreign keys
- seed database with admin user, reference data, and sample sale

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7ed7b2883328c585b1794eea5b7