### PR TITLE
Add item routes with parameter support

### DIFF
--- a/app/lib/Router.php
+++ b/app/lib/Router.php
@@ -1,9 +1,43 @@
 <?php
 class Router
 {
+    private $routes = [
+        'GET' => [
+            'items' => 'ItemController@index',
+            'items/{id}' => 'ItemController@show',
+            'items/create' => 'ItemController@create',
+            'items/{id}/edit' => 'ItemController@edit',
+        ],
+        'POST' => [
+            'items' => 'ItemController@store',
+            'items/{id}' => 'ItemController@update',
+            'items/{id}/delete' => 'ItemController@destroy',
+        ],
+    ];
+
     public function dispatch($uri)
     {
         $path = trim(parse_url($uri, PHP_URL_PATH), '/');
+        $httpMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+        if (isset($this->routes[$httpMethod])) {
+            foreach ($this->routes[$httpMethod] as $route => $action) {
+                $pattern = '#^' . preg_replace('#\{[^/]+\}#', '([^/]+)', $route) . '$#';
+                if (preg_match($pattern, $path, $matches)) {
+                    array_shift($matches);
+                    list($controllerName, $method) = explode('@', $action);
+                    $controllerFile = __DIR__ . '/../controllers/' . $controllerName . '.php';
+                    if (file_exists($controllerFile)) {
+                        $controller = new $controllerName();
+                        if (method_exists($controller, $method)) {
+                            call_user_func_array([$controller, $method], $matches);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         $segments = $path === '' ? [] : explode('/', $path);
 
         $controllerName = !empty($segments[0]) ? ucfirst($segments[0]) . 'Controller' : 'HomeController';


### PR DESCRIPTION
## Summary
- add explicit GET/POST routes for items
- support `{id}` parameter extraction in router dispatch

## Testing
- `php -l app/lib/Router.php`


------
https://chatgpt.com/codex/tasks/task_e_689fd2964a808332a2d2eb9d6ab152c1