### PR TITLE
Add items table and seed data

### DIFF
--- a/scripts/db_migrations.sql
+++ b/scripts/db_migrations.sql
@@ -76,3 +76,10 @@ CREATE TABLE audit_logs (
     INDEX idx_log_user (user_id),
     CONSTRAINT fk_logs_user FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB;
+
+CREATE TABLE items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    quantity INT NOT NULL,
+    price DECIMAL(10,2) NOT NULL
+) ENGINE=InnoDB;

--- a/scripts/seeders.sql
+++ b/scripts/seeders.sql
@@ -16,6 +16,12 @@ INSERT INTO products (category_id, supplier_id, name, price, stock) VALUES
 (1, 1, 'Laptop', 999.99, 10),
 (2, 1, 'Office Chair', 199.99, 20);
 
+INSERT INTO items (name, quantity, price) VALUES
+('Keyboard', 15, 49.99),
+('Mouse', 30, 19.95),
+('Monitor', 8, 129.50),
+('USB Cable', 50, 5.99);
+
 INSERT INTO workers (user_id, name, contact_info) VALUES
 (2, 'John Doe', 'john@example.com');
 


### PR DESCRIPTION
## Summary
- add `items` table to database migrations with fields for id, name, quantity, and price
- seed multiple sample items with varied quantities and prices

## Testing
- `php -l app/models/Item.php`
- `php -l app/controllers/ItemController.php`


------
https://chatgpt.com/codex/tasks/task_e_689fd37f0f3c8332a28afc9f063782a9